### PR TITLE
feat: 현재 페이지에 따라 헤더 색상 변경  #1

### DIFF
--- a/vue-project/src/components/common/HeaderComponent.vue
+++ b/vue-project/src/components/common/HeaderComponent.vue
@@ -1,4 +1,8 @@
-<script setup></script>
+<script setup>
+import { useRoute } from 'vue-router';
+
+const route = useRoute();
+</script>
 
 <template>
     <div class="header">
@@ -17,9 +21,9 @@
             <router-link to="/"><img src="@/assets/img/logo.png" /></router-link>
         </div>
         <div class="nav">
-            <div class="menu-item"><router-link to="/diary/home">금쪽일기</router-link></div>
-            <div class="menu-item"><router-link to="/article/list">꿀팁</router-link></div>
-            <div class="menu-item"><router-link to="/survey">진단</router-link></div>
+            <div class="menu-item" :class="{ 'active' : route.path.startsWith('/diary')}"><router-link to="/diary/home">금쪽일기</router-link></div>
+            <div class="menu-item" :class="{ 'active' : route.path.startsWith('/article')}"><router-link to="/article/list">꿀팁</router-link></div>
+            <div class="menu-item" :class="{ 'active' : route.path.startsWith('/survey')}"><router-link to="/survey">진단</router-link></div>
             <div class="menu-item"><a href="#">주변병원</a></div>
         </div>
     </div>
@@ -67,6 +71,10 @@ a:hover {
 }
 
 .menu-item:hover {
+    background-image: url(../../assets/img/sticker3.png);
+}
+
+.menu-item.active{
     background-image: url(../../assets/img/sticker3.png);
 }
 


### PR DESCRIPTION
### Motivation 
- close #1 

### Key Change
-현재 페이지 url에 따라 헤더 메뉴 색상 변경 구현
<img width="1281" alt="image" src="https://github.com/MyGoldenKids/goldenkid-frontend/assets/79824230/70a38e18-3822-4a81-a1f9-d781b7041e14">



### To Reviewer
- 주변 병원 메뉴는 아직 구현되지 않아 생략하였습니다.
