### PR TITLE
fix: 회원정보 수정 시 변경한 닉네임으로 세션에 저장 #46

### DIFF
--- a/vue-project/src/components/member/MemberMyPageComponent.vue
+++ b/vue-project/src/components/member/MemberMyPageComponent.vue
@@ -35,6 +35,9 @@ function submitForm() {
         memberDetail,
         () => {
             console.log("회원정보 수정 성공");
+            // 회원정보 수정 시 수정한 닉네임으로 업데이트
+            sessionStorage.setItem("nickname", memberDetail.value.nickname);
+            store.memberInfo.nickname = memberDetail.value.nickname;
         },
         () => {
             console.log("회원정보 수정 실패");


### PR DESCRIPTION
### Motivation 
- close #46

### Key Change
- 회원정보 수정 시 변경한 닉네임으로 업데이트 하여 스토어에 저장

### To Reviewer
- 마이페이지에서 회원정보 수정 후 수정한 닉네임으로 스토어 및 세션 storage에 저장하도록 변경하였습니다.
